### PR TITLE
docs: fix simple typo, direcly -> directly

### DIFF
--- a/custom_backend/glfw/glew/glew.c
+++ b/custom_backend/glfw/glew/glew.c
@@ -60,7 +60,7 @@
 #if defined(GLEW_EGL)
 #elif defined(GLEW_REGAL)
 
-/* In GLEW_REGAL mode we call direcly into the linked
+/* In GLEW_REGAL mode we call directly into the linked
    libRegal.so glGetProcAddressREGAL for looking up
    the GL function pointers. */
 


### PR DESCRIPTION
There is a small typo in custom_backend/glfw/glew/glew.c.

Should read `directly` rather than `direcly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md