### PR TITLE
Add loadImageFromMemory() to load images from data buffers

### DIFF
--- a/src/fbgraphics.h
+++ b/src/fbgraphics.h
@@ -589,6 +589,7 @@
     */
     extern struct _fbg_img *fbg_createImage(struct _fbg *fbg, unsigned int width, unsigned int height);
 
+#ifndef WITHOUT_STDIO
     //! load a PNG image from a file (lodePNG library)
     /*!
       \param fbg pointer to a FBG context / data structure
@@ -611,8 +612,6 @@
     extern struct _fbg_img *fbg_loadJPEG(struct _fbg *fbg, const char *filename);
 #endif
 
-#ifndef WITHOUT_STB_IMAGE
-
     //! load an image from a file (STB Image library)
     /*!
       \param fbg pointer to a FBG context / data structure
@@ -620,6 +619,7 @@
       \return _fbg_img data structure pointer
       \sa fbg_freeImage(), fbg_image(), fbg_imageFlip(), fbg_createFont(), fbg_imageClip(), fbg_loadImage(), fbg_imageEx(), fbg_imageScale(), fbg_imageColorkey()
     */
+#ifndef WITHOUT_STB_IMAGE
     extern struct _fbg_img *fbg_loadSTBImage(struct _fbg *fbg, const char *filename);
 #endif
 
@@ -631,6 +631,29 @@
       \sa fbg_freeImage(), fbg_image(), fbg_imageFlip(), fbg_createFont(), fbg_imageClip(), fbg_loadPNG(), fbg_loadJPEG(), fbg_imageEx(), fbg_imageScale(), fbg_imageColorkey()
     */
     extern struct _fbg_img *fbg_loadImage(struct _fbg *fbg, const char *filename);
+#endif // WITHOUT_STDIO
+
+    //! load an image from memory (STB Image library)
+    /*!
+      \param fbg pointer to a FBG context / data structure
+      \param data The image data from memory.
+      \param size The size of the image in bytes.
+      \return _fbg_img data structure pointer
+      \sa fbg_freeImage(), fbg_image(), fbg_imageFlip(), fbg_createFont(), fbg_imageClip(), fbg_loadPNG(), fbg_loadJPEG(), fbg_imageEx(), fbg_imageScale(), fbg_imageColorkey()
+    */
+#ifndef WITHOUT_STB_IMAGE
+    extern struct _fbg_img *fbg_loadSTBImageFromMemory(struct _fbg *fbg, const unsigned char *data, int size);
+#endif
+
+    //! load an image from memory
+    /*!
+      \param fbg pointer to a FBG context / data structure
+      \param data The image data from memory.
+      \param size The size of the image in bytes.
+      \return _fbg_img data structure pointer
+      \sa fbg_freeImage(), fbg_image(), fbg_imageFlip(), fbg_createFont(), fbg_imageClip(), fbg_loadPNG(), fbg_loadJPEG(), fbg_imageEx(), fbg_imageScale(), fbg_imageColorkey()
+    */
+    extern struct _fbg_img *fbg_loadImageFromMemory(struct _fbg *fbg, const unsigned char *data, int size);
 
     //! draw an image
     /*!


### PR DESCRIPTION
This allows loading images directly from memory rather than having to access the file system. In addition, it also allows disabling the image file loading functions via `WITHOUT_STDIO`.

``` c
    //! load an image from memory
    /*!
      \param fbg pointer to a FBG context / data structure
      \param data The image data from memory.
      \param size The size of the image in bytes.
      \return _fbg_img data structure pointer
      \sa fbg_freeImage(), fbg_image(), fbg_imageFlip(), fbg_createFont(), fbg_imageClip(), fbg_loadPNG(), fbg_loadJPEG(), fbg_imageEx(), fbg_imageScale(), fbg_imageColorkey()
    */
    extern struct _fbg_img *fbg_loadImageFromMemory(struct _fbg *fbg, const unsigned char *data, int size);
```

One benefit to having this is that it allows loading images from .zip files through [PhysFS](https://www.icculus.org/physfs/).

Fixes #13